### PR TITLE
Reset the userInput on submit

### DIFF
--- a/src/UserInput.vue
+++ b/src/UserInput.vue
@@ -76,6 +76,7 @@ export default {
     handleKey (event) {
       if (event.keyCode === 13 && !event.shiftKey) {
         this._submitText(event)
+        event.preventDefault();
       }
     },
     _submitText (event) {


### PR DESCRIPTION
Prevents the unnecessary line break from executing when submitting a new message.