### PR TITLE
Remove unused 'table' class in user list

### DIFF
--- a/src/UserList.vue
+++ b/src/UserList.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="user-list">
-    <table class="table" style="padding-top: 5px">
+    <table class="" style="padding-top: 5px">
       <tbody>
         <tr v-for="user in participants" :key="user.id">
             <td style="text-align: center;"><img :src="user.imageUrl" class="img-msg"/></td>


### PR DESCRIPTION
It introduces conflict with bootstrap, which has a `table` class. I didn't notice it when copying the code from #30 .

My bad.