### PR TITLE
comma was missing after alwaysScrollToBottom: false in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ export default {
           text: '#565867'
         }
       }, // specifies the color scheme for the component
-      alwaysScrollToBottom: false // when set to true always scrolls the chat to the bottom when new events are in (new message, user starts typing...)
+      alwaysScrollToBottom: false, // when set to true always scrolls the chat to the bottom when new events are in (new message, user starts typing...)
       messageStyling: true // enables *bold* /emph/ _underline_ and such (more info at github.com/mattezza/msgdown)
     }
   },

--- a/src/FileIcons.vue
+++ b/src/FileIcons.vue
@@ -1,5 +1,4 @@
 <template>
-  <label htmlFor='file-input' >
     <button
       class="sc-user-input--file-icon-wrapper"
       type='button'
@@ -19,7 +18,6 @@
       </svg>
     </button>
     <input type='file' id='file-input' @change="_handleChange" @click="_handleClick" />
-  </label>
 </template>
 
 <script>


### PR DESCRIPTION
In the readme file to comma was missing after alwaysScrollToBottom: false causing an error when you try to use the demo code.