### PR TITLE
typo fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ export default {
         }
       }, // specifies the color scheme for the component
       alwaysScrollToBottom: false // when set to true always scrolls the chat to the bottom when new events are in (new message, user starts typing...)
-      messageStyling: true // enables *bold* /emph/ _underline_ and such (more info at github.com/mattezza/msgdown)
+      messageStyling: true // enables *bold* /emph/ _underline_ and such (more info at github.com/mattmezza/msgdown)
     }
   },
   methods: {


### PR DESCRIPTION
I wanted to fix this typo, because when I tried to use the messageStyling feauture I was happy to have that comment there, checked the link, and it was not working... It was quite a shocking moment... :)