### PR TITLE
Added ScrollToTop event for triggering pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Vue.use(Chat)
       :showTypingIndicator="showTypingIndicator"
       :colors="colors"
       :alwaysScrollToBottom="alwaysScrollToBottom"
-      :messageStyling="messageStyling" />
+      :messageStyling="messageStyling"
+      @scrollToTop="handleScrollToTop" />
   </div>
 </template>
 ```
@@ -133,7 +134,12 @@ export default {
     closeChat () {
       // called when the user clicks on the botton to close the chat
       this.isChatOpen = false
+    },
+    handleScrollToTop () {
+      // called when the user scrolls message list to top
+      // leverage pagination for loading another page of messages
     }
+
   }
 }
 ```

--- a/src/ChatWindow.vue
+++ b/src/ChatWindow.vue
@@ -19,6 +19,7 @@
       :colors="colors"
       :alwaysScrollToBottom="alwaysScrollToBottom"
       :messageStyling="messageStyling"
+      @scrollToTop="$emit('scrollToTop')"
     />
     <UserInput
       v-if="!showUserList"

--- a/src/Launcher.vue
+++ b/src/Launcher.vue
@@ -22,6 +22,7 @@
       :colors="colors"
       :alwaysScrollToBottom="alwaysScrollToBottom"
       :messageStyling="messageStyling"
+      @scrollToTop="$emit('scrollToTop')"
     />
   </div>
 </template>

--- a/src/MessageList.vue
+++ b/src/MessageList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="sc-message-list" ref="scrollList" :style="{backgroundColor: colors.messageList.bg}">
+  <div class="sc-message-list" ref="scrollList" :style="{backgroundColor: colors.messageList.bg}" @scroll="handleScroll">
     <Message v-for="(message, idx) in messages" :message="message" :chatImageUrl="chatImageUrl(message.author)" :authorName="authorName(message.author)" :key="idx" :colors="colors" :messageStyling="messageStyling" />
     <Message v-show="showTypingIndicator !== ''" :message="{author: showTypingIndicator, type: 'typing'}" :chatImageUrl="chatImageUrl(showTypingIndicator)" :colors="colors" :messageStyling="messageStyling" />
   </div>
@@ -41,6 +41,11 @@ export default {
   methods: {
     _scrollDown () {
       this.$refs.scrollList.scrollTop = this.$refs.scrollList.scrollHeight
+    },
+    handleScroll (e) {
+        if (e.target.scrollTop === 0) {
+            this.$emit('scrollToTop')
+        }
     },
     shouldScrollToBottom() {
       return this.alwaysScrollToBottom || (this.$refs.scrollList.scrollTop > this.$refs.scrollList.scrollHeight - 600)


### PR DESCRIPTION
Hello, here the code for emitting an event named "scrollToTop" when user scrolls message list to top.

For improving usability I see at least another change, but you should definitively decide if it is needed.
After the user scrolls to top, and another bunch of messages is loaded, the desired user experience in my opinion should be to shift some pixel down the div again. By this way, if the user continues scrolling up, other messages will automatically be fetched. Otherwise the user needs to scroll manually down and up message list in order to trigger another page load.
However it is not easy (at least to me) to understand how to trigger this shift after the user loads the page.

So I end up in the client code with a handler like this:
 
```
        handleScroll () {
                this.alwaysScrollToBottom = false
                // Load a new page                
                document.querySelector('.sc-message-list').scrollTo(0,10)
                this.alwaysScrollToBottom = true
       }
```

It works, but obviusly the querySelector is not really nice here.

