### PR TITLE
Fix for TypeError in chatWindowTitle() of Launcher.vue

### DIFF
--- a/src/Launcher.vue
+++ b/src/Launcher.vue
@@ -142,7 +142,9 @@ export default {
         return this.title
       }
 
-      if (this.participants.length > 1) {
+      if (this.participants.length === 0) {
+        return 'You'
+      } else if (this.participants.length > 1) {
         return 'You, ' + this.participants[0].name + ' & others'
       } else {
         return 'You & ' + this.participants[0].name

--- a/src/Message.vue
+++ b/src/Message.vue
@@ -7,7 +7,7 @@
       }">
       <div v-if="message.type !== 'system'" :title="authorName" class="sc-message--avatar" :style="{
         backgroundImage: `url(${chatImageUrl})`
-      }" v-tooltip="message.author"></div>
+      }" v-tooltip="authorName"></div>
       <TextMessage v-if="message.type === 'text'" :data="message.data" :messageColors="determineMessageColors()" :messageStyling="messageStyling" />
       <EmojiMessage v-else-if="message.type === 'emoji'" :data="message.data" />
       <FileMessage v-else-if="message.type === 'file'" :data="message.data" :messageColors="determineMessageColors()" />


### PR DESCRIPTION
My changes:
1. Added check if participants array is empty. In this case 'You' gets returned.

2. The tooltip of message from other participants where displaying their id because it uses message.author and that's its id. My change uses the authorName passed by the props