### PR TITLE
Feature/issue 86 Add option to disable userlist toggle

### DIFF
--- a/src/ChatWindow.vue
+++ b/src/ChatWindow.vue
@@ -5,6 +5,7 @@
       :imageUrl="titleImageUrl"
       :onClose="onClose"
       :colors="colors"
+      :disableUserListToggle="disableUserListToggle"
       @userList="handleUserListToggle"
     />
     <UserList 
@@ -102,6 +103,10 @@ export default {
     messageStyling: {
       type: Boolean,
       required: true
+    },
+    disableUserListToggle: {
+      type: Boolean,
+      default: false
     }
   },
   data() {

--- a/src/Header.vue
+++ b/src/Header.vue
@@ -2,7 +2,7 @@
   <div class="sc-header" :style="{background: colors.header.bg, color: colors.header.text}">
     <img class="sc-header--img" :src="imageUrl" alt="" v-if="imageUrl" />
     <div v-if="!disableUserListToggle" class="sc-header--title enabled" @click="toggleUserList"> {{title}} </div>
-    <div v-else class="sc-header--title" @click="toggleUserList"> {{title}} </div>
+    <div v-else class="sc-header--title"> {{title}} </div>
     <div class="sc-header--close-button" @click="onClose">
       <img src="./assets/close-icon.png" alt="" />
     </div>

--- a/src/Header.vue
+++ b/src/Header.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="sc-header" :style="{background: colors.header.bg, color: colors.header.text}">
     <img class="sc-header--img" :src="imageUrl" alt="" v-if="imageUrl" />
-    <div class="sc-header--title" @click="toggleUserList"> {{title}} </div>
+    <div v-if="!disableUserListToggle" class="sc-header--title enabled" @click="toggleUserList"> {{title}} </div>
+    <div v-else class="sc-header--title" @click="toggleUserList"> {{title}} </div>
     <div class="sc-header--close-button" @click="onClose">
       <img src="./assets/close-icon.png" alt="" />
     </div>
@@ -25,6 +26,10 @@ export default {
     colors: {
       type: Object,
       required: true
+    },
+    disableUserListToggle: {
+      type: Boolean,
+      default: false
     }
   },
   methods: {
@@ -63,11 +68,14 @@ export default {
   padding: 10px;
   flex: 1;
   user-select: none;
+}
+
+.sc-header--title.enabled {
   cursor: pointer;
   border-radius: 5px;
 }
 
-.sc-header--title:hover {
+.sc-header--title.enabled:hover {
   box-shadow: 0px 2px 5px rgba(0.2, 0.2, 0.5, .1);
 }
 

--- a/src/Launcher.vue
+++ b/src/Launcher.vue
@@ -22,6 +22,7 @@
       :colors="colors"
       :alwaysScrollToBottom="alwaysScrollToBottom"
       :messageStyling="messageStyling"
+      :disableUserListToggle="disableUserListToggle"
       @scrollToTop="$emit('scrollToTop')"
       @onType="$emit('onType')"
     />
@@ -134,6 +135,10 @@ export default {
     messageStyling: {
       type: Boolean,
       default: () => false
+    },
+    disableUserListToggle: {
+      type: Boolean,
+      default: false
     }
   },
   computed: {


### PR DESCRIPTION
I use this library to develop my own products.
Added props to disable userlisttoggle, as it was necessary to hide the userlist.

If disabled, the user list will not be displayed when you click the title. In addition, the style of hover is also disabled.