### PR TITLE
Align user input buttons to the right

### DIFF
--- a/src/UserInput.vue
+++ b/src/UserInput.vue
@@ -288,6 +288,7 @@ export default {
   right: 30px;
   height: 100%;
   display: flex;
+  justify-content: flex-end;
 }
 
 .sc-user-input--button:first-of-type {


### PR DESCRIPTION
With default content justification, alignment of the send button in the user input component becomes awkward when the file and emoji button are hidden. With flex-direction: end, all visible buttons are aligned to the right.