### PR TITLE
feature: do not delete user input in case sending fails

### DIFF
--- a/src/UserInput.vue
+++ b/src/UserInput.vue
@@ -152,6 +152,20 @@ export default {
     _submitSuggestion(suggestion) {
       this.onSubmit({author: 'me', type: 'text', data: { text: suggestion }})
     },
+    _checkSubmitSuccess (success) {
+      if (Promise !== undefined) {
+        Promise.resolve(success).then(function (wasSuccessful) {
+          if (wasSuccessful === undefined || wasSuccessful) {
+            this.file = null
+            this.$refs.userInput.innerHTML = '';
+          }
+        }.bind(this));
+
+      } else {
+        this.file = null
+        this.$refs.userInput.innerHTML = '';
+      }
+    },
     _submitText (event) {
       const text = this.$refs.userInput.textContent
       const file = this.file
@@ -159,31 +173,27 @@ export default {
         this._submitTextWhenFile(event, text, file)
       } else {
         if (text && text.length > 0) {
-          this.onSubmit({
+          this._checkSubmitSuccess(this.onSubmit({
             author: 'me',
             type: 'text',
             data: { text }
-          });
-          this.$refs.userInput.innerHTML = ''
+          }));
         }
       }
     },
     _submitTextWhenFile(event, text, file) {
-      if (text && text.length > 0) {  
-        this.onSubmit({
+      if (text && text.length > 0) {
+        this._checkSubmitSuccess(this.onSubmit({
           author: 'me',
           type: 'file',
           data: { text, file }
-        })
-        this.file = null
-        this.$refs.userInput.innerHTML = ''
+        }))
       } else {
-        this.onSubmit({
+        this._checkSubmitSuccess(this.onSubmit({
           author: 'me',
           type: 'file',
           data: { file }
-        })
-        this.file = null
+        }))
       }
     },
     _editText (event) {
@@ -199,11 +209,11 @@ export default {
       }
     },
     _handleEmojiPicked (emoji) {
-      this.onSubmit({
+      this._checkSubmitSuccess(this.onSubmit({
         author: 'me',
         type: 'emoji',
         data: { emoji }
-      })
+      }))
     },
     _handleFileSubmit (file) {
       this.file = file


### PR DESCRIPTION
In case the sending callback function returns "false",
then sending the message is regarded as failed. In such cases
the user input field is not deleted. Then the user might try
to resolve sending issues and try again, without loosing
its message.

Previously the input field was deleted in any case.
If the message is sent to a remote server via network,
the network might be down currently and even on
purpose. Trying to send a message in that situation
had lead to losing the message.

Now, the message is retained until the callback to send
the message returns. The return value is evaluated
for any sign of success. On success, the input field is
cleared and in failure, its content is maintained.