### PR TITLE
feature: create TypeScript type definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "vue-js-chat"
   ],
   "devDependencies": {
+    "@types/vue": "^2.0.0",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.4",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.3.1",
   "description": "A simple and beautiful Vue chat component backend agnostic.",
   "main": "./src/index.js",
+  "types": "./src/index.d.ts",
   "repository": "https://github.com/mattmezza/vue-beautiful-chat.git",
   "author": "Matteo Merola <mattmezza@gmail.com>",
   "license": "MIT",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,78 @@
+import Vue                                  from 'vue';
+import { PluginObject, PluginFunction }     from 'vue';
+
+// augment vue for typescript
+declare module 'vue/types/vue' {
+    export interface Vue {
+        $chat: any;
+    }
+}
+
+export enum ChatMessageTypes {
+    text  = 'text',
+    emoji = 'emoji',
+    file  = 'file',
+}
+
+interface ChatMessageTextData {
+    meta?: string;
+    text: string;
+}
+
+interface ChatMessageFileDataItem {
+    meta?: string;
+    name: string;
+    url: string;
+}
+
+interface ChatMessageFileData {
+    meta?: string;
+    file: ChatMessageFileDataItem;
+}
+
+interface ChatMessageEmojiData {
+    meta?: string;
+    emoji: string;
+}
+
+
+interface ChatMessageBase {
+    id?: string;
+    author?: string;
+    type: ChatMessageTypes;
+    isEdited?: boolean;
+    suggestions?: string[];
+    meta?: string;
+
+    [key: string]: any;
+}
+
+export interface ChatMessageText extends ChatMessageBase {
+    type: ChatMessageTypes.text;
+    data: ChatMessageTextData;
+}
+
+export interface ChatMessageFile extends ChatMessageBase {
+    type: ChatMessageTypes.file;
+    data: ChatMessageFileData;
+}
+
+export interface ChatMessageEmoji extends ChatMessageBase {
+    type: ChatMessageTypes.emoji;
+    data: ChatMessageEmojiData;
+}
+
+export type ChatMessage = ChatMessageText | ChatMessageFile | ChatMessageEmoji;
+
+
+
+interface ChatPluginOptions {
+    componentName?: string
+}
+
+
+export declare class Chat implements PluginObject<ChatPluginOptions> {
+    install: PluginFunction<ChatPluginOptions>;
+    static install: PluginFunction<ChatPluginOptions>;
+}
+export default Chat;


### PR DESCRIPTION
It seems as if a lot of developers use Vue with TypeScript.
The next major Vue version is said to support TypeScript natively. Therefore it would be very helpful to have TypeScript types available with vue-beautiful-chat.

The type definition could be improved, though. Unfortunately it was impossible to define just one "install" function. Both - static and member func - had to be defined to make TypeScript happy using it with Vue in my project.