### PR TITLE
'focus' error solved

### DIFF
--- a/src/UserInput.vue
+++ b/src/UserInput.vue
@@ -232,7 +232,9 @@ export default {
   },
   mounted() {
     this.$root.$on('focusUserInput', () => {
-      this.focusUserInput()
+      if (this.$refs.userInput) {
+        this.focusUserInput()
+      }
     })
   }
 }


### PR DESCRIPTION
"Cannot read property 'focus' of undefined"

This error occurs when toggling the launcher button, only if the client previously cliked the userList button.

By this change, this error disapears.