### PR TITLE
Fixes #143: Typing indicator displays avatar; no more requests to 'undefined'

### DIFF
--- a/src/Message.vue
+++ b/src/Message.vue
@@ -5,19 +5,19 @@
         received: message.author !== 'me' && message.type !== 'system',
         system: message.type === 'system'
       }">
-      <slot 
+      <slot
         name="user-avatar"
-        :message="message" 
+        :message="message"
         :user="user">
-          <div v-if="message.type !== 'system'" :title="authorName" class="sc-message--avatar" :style="{
+          <div v-if="message.type !== 'system' && authorName && authorName !== 'me'" :title="authorName" class="sc-message--avatar" :style="{
             backgroundImage: `url(${chatImageUrl})`
           }" v-tooltip="authorName"></div>
       </slot>
 
-      <TextMessage 
-        v-if="message.type === 'text'" 
-        :message="message" 
-        :messageColors="determineMessageColors()" 
+      <TextMessage
+        v-if="message.type === 'text'"
+        :message="message"
+        :messageColors="messageColors"
         :messageStyling="messageStyling"
         @remove="$emit('remove')">
           <template v-slot:default="scopedProps">
@@ -30,9 +30,9 @@
           </template>
       </TextMessage>
       <EmojiMessage v-else-if="message.type === 'emoji'" :data="message.data" />
-      <FileMessage v-else-if="message.type === 'file'" :data="message.data" :messageColors="determineMessageColors()" />
-      <TypingMessage v-else-if="message.type === 'typing'" :messageColors="determineMessageColors()" />
-      <SystemMessage v-else-if="message.type === 'system'" :data="message.data" :messageColors="determineMessageColors()">
+      <FileMessage v-else-if="message.type === 'file'" :data="message.data" :messageColors="messageColors" />
+      <TypingMessage v-else-if="message.type === 'typing'" :messageColors="messageColors" />
+      <SystemMessage v-else-if="message.type === 'system'" :data="message.data" :messageColors="messageColors">
           <slot name="system-message-body" :message="message.data">
           </slot>
       </SystemMessage>
@@ -50,11 +50,6 @@ import chatIcon from './assets/chat-icon.svg'
 import store from "./store/";
 
 export default {
-  data () {
-    return {
-
-    }
-  },
   components: {
     TextMessage,
     FileMessage,
@@ -80,12 +75,15 @@ export default {
       required: true
     }
   },
-  methods: {
-    sentColorsStyle() {
-      return {
-        color: this.colors.sentMessage.text,
-        backgroundColor: this.colors.sentMessage.bg
-      }
+  computed:{
+    authorName(){
+      return this.user && this.user.name;
+    },
+    chatImageUrl(){
+      return (this.user && this.user.imageUrl) || chatIcon;
+    },
+    messageColors() {
+      return this.message.author === 'me' ? this.sentColorsStyle : this.receivedColorsStyle
     },
     receivedColorsStyle() {
       return {
@@ -93,16 +91,11 @@ export default {
         backgroundColor: this.colors.receivedMessage.bg
       }
     },
-    determineMessageColors() {
-      return this.message.author === 'me' ? this.sentColorsStyle() : this.receivedColorsStyle()
-    }
-  },
-  computed:{
-    authorName(){
-      return this.user && this.user.name;
-    },
-    chatImageUrl(){
-      return (this.user && this.user.imageUrl) || this.chatIcon;
+    sentColorsStyle() {
+      return {
+        color: this.colors.sentMessage.text,
+        backgroundColor: this.colors.sentMessage.bg
+      }
     }
   }
 }

--- a/src/MessageList.vue
+++ b/src/MessageList.vue
@@ -14,7 +14,7 @@
         </slot>
       </template>
     </Message>
-    <Message v-show="showTypingIndicator !== ''" :message="{author: showTypingIndicator, type: 'typing'}" :user="{}" :colors="colors" :messageStyling="messageStyling" />
+    <Message v-show="showTypingIndicator !== ''" :message="{author: showTypingIndicator, type: 'typing'}" :user="profile(showTypingIndicator)" :colors="colors" :messageStyling="messageStyling" />
   </div>
 </template>
 <script>

--- a/src/UserInputButton.vue
+++ b/src/UserInputButton.vue
@@ -35,18 +35,5 @@ export default {
   margin: 0px;
   outline: none;
   cursor: pointer;
-  &:focus{
-    outline: none;
-  }
-  svg {
-    height: 20px;
-    width: 20px;
-    cursor: pointer;
-    align-self: center;
-    outline: none;
-    &:hover path{
-      filter: contrast(15%);
-    }
-  }
 }
 </style>


### PR DESCRIPTION
- Updating `:user="{}"` to `:user="profile(showTypingIndicator)"` in MessageList component allows Message component to compute a proper `chatImageUrl`.
- In case an `imageUrl` is not defined for the user, `chatImageUrl` was erroneously using `this.chatIcon`. This data item was never declared on the component. It is updated to just `chatIcon` (imported ref), and the empty `data()` declaration is removed.
- The `v-if` condition to display the avatar is updated from `message.type !== 'system'` to `message.type !== 'system' && authorName && authorName !== 'me' ` to avoid trying to load the current user's avatar image (since it's undefined).

The above three changes handle all cases where ``backgroundImage: `url(${chatImageUrl})` `` would've resolved to ``backgroundImage: `url(undefined)` ``, resulting in the following 404s (as seen on the demo):

<image src="https://user-images.githubusercontent.com/26761352/80820439-7cc83c80-8bf4-11ea-82b2-77f744d3cfe3.png" height="200" />

The following two changes are optimizations:

- `determineMessageColors` method and its dependencies are converted to computed properties to not have them called on every render (see https://vuejs.org/v2/guide/computed.html#Computed-Caching-vs-Methods). This still allows dynamic color definition updates.
- UserInputButton.vue was using SCSS syntax without declaring `lang="scss"` on the `style` block, resulting in garbage:
  <image src="https://user-images.githubusercontent.com/26761352/80820824-4212d400-8bf5-11ea-9f1a-e2993089c6f3.png" height="300" />
  Removed since the styles don't actually affect anything as I found after parsing as SCSS.

To link to issue: closes #143