### PR TITLE
Auto-lint on commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "eslint-plugin-vue": "^6.2.2",
-    "lint-staged": "^10.1.1",
+    "husky": "^4.3.0",
+    "lint-staged": "^10.4.2",
     "node-forge": "^0.10.0",
     "node-sass": "^4.13.1",
     "prettier": "^2.0.2",
@@ -53,5 +54,13 @@
   ],
   "bugs": {
     "url": "https://github.com/mattmezza/vue-beautiful-chat/issues"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.{js,vue}": "vue-cli-service lint"
   }
 }


### PR DESCRIPTION
This should save everyone's time : ]

By the way, I do not use Yarn so I haven't updated yarn.lock. Is there anything specific you use it for, @mattmezza? I've generally found that package.json is enough for most purposes (even to pin dependencies to their exact versions). The only other use case I've heard for lockfiles is in CI environment where installs are "slightly" faster, but we don't really have any integration tests/env.