### PR TITLE
Fixes #209: Allow inserting emojis alongside text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ yarn-error.log*
 
 # Misc
 .ghnpmpkgtoken
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ For more detailed examples see the demo folder.
 | *close | Function | The function passed to the component that mutates the above mentioned bool toggle for closing the chat |
 | messageList | [message] | An array of message objects to be rendered as a conversation. |
 | showEmoji | Boolean | A bool indicating whether or not to show the emoji button
+| sendEmojisDirectly | Boolean | A bool indicating whether or not to send emojis directly as a message as opposed to inserting them into the user input
 | showFile | Boolean | A bool indicating whether or not to show the file chooser button
 | showDeletion | Boolean | A bool indicating whether or not to show the edit button for a message
 | showConfirmationDeletion | Boolean | A bool indicating whether or not to show the confirmation text when we remove a message

--- a/src/ChatWindow.vue
+++ b/src/ChatWindow.vue
@@ -49,6 +49,7 @@
     <UserInput
       v-if="!showUserList"
       :show-emoji="showEmoji"
+      :send-emojis-directly="sendEmojisDirectly"
       :on-submit="onUserInputSubmit"
       :suggestions="getSuggestions()"
       :show-file="showFile"
@@ -77,6 +78,10 @@ export default {
     showEmoji: {
       type: Boolean,
       default: false
+    },
+    sendEmojisDirectly: {
+      type: Boolean,
+      default: true
     },
     showFile: {
       type: Boolean,

--- a/src/Launcher.vue
+++ b/src/Launcher.vue
@@ -20,6 +20,7 @@
       :title="chatWindowTitle"
       :is-open="isOpen"
       :show-emoji="showEmoji"
+      :send-emojis-directly="sendEmojisDirectly"
       :show-file="showFile"
       :show-confirmation-deletion="showConfirmationDeletion"
       :confirmation-deletion-message="confirmationDeletionMessage"
@@ -91,7 +92,11 @@ export default {
     },
     showEmoji: {
       type: Boolean,
-      default: false
+      default: () => false
+    },
+    sendEmojisDirectly: {
+      type: Boolean,
+      default: () => true
     },
     showEdition: {
       type: Boolean,

--- a/src/UserInput.vue
+++ b/src/UserInput.vue
@@ -181,9 +181,10 @@ export default {
     document.addEventListener('selectionchange', () => {
       var selection = document.getSelection()
       if (
-        selection.anchorNode &&
-        selection.anchorNode != this.$refs.userInput &&
-        selection.anchorNode.parentNode != this.$refs.userInput
+        !selection ||
+        !selection.anchorNode ||
+        (selection.anchorNode != this.$refs.userInput &&
+          selection.anchorNode.parentNode != this.$refs.userInput)
       ) {
         return
       }

--- a/src/UserInput.vue
+++ b/src/UserInput.vue
@@ -181,6 +181,7 @@ export default {
     document.addEventListener('selectionchange', () => {
       var selection = document.getSelection()
       if (
+        selection.anchorNode &&
         selection.anchorNode != this.$refs.userInput &&
         selection.anchorNode.parentNode != this.$refs.userInput
       ) {
@@ -307,7 +308,9 @@ export default {
     _insertEmoji(emoji) {
       var range = this.previousSelectionRange
       if (!range) {
-        console.log('First child: ' + this.$refs.userInput.firstChild)
+        if (!this.$refs.userInput.firstChild) {
+          this.$refs.userInput.append(document.createTextNode(''))
+        }
         range = document.createRange()
         range.setStart(this.$refs.userInput.firstChild, this.$refs.userInput.textContent.length)
         range.collapse(true)

--- a/src/UserInput.vue
+++ b/src/UserInput.vue
@@ -121,6 +121,10 @@ export default {
       type: Boolean,
       default: () => false
     },
+    sendEmojisDirectly: {
+      type: Boolean,
+      default: () => true
+    },
     suggestions: {
       type: Array,
       default: () => []
@@ -145,7 +149,8 @@ export default {
   data() {
     return {
       file: null,
-      inputActive: false
+      inputActive: false,
+      previousSelectionRange: null
     }
   },
   computed: {
@@ -170,6 +175,22 @@ export default {
     this.$root.$on('focusUserInput', () => {
       if (this.$refs.userInput) {
         this.focusUserInput()
+      }
+    })
+
+    document.addEventListener('selectionchange', () => {
+      var selection = document.getSelection()
+      if (
+        selection.anchorNode != this.$refs.userInput &&
+        selection.anchorNode.parentNode != this.$refs.userInput
+      ) {
+        return
+      }
+
+      if (selection.rangeCount) {
+        this.previousSelectionRange = selection.getRangeAt(0).cloneRange()
+      } else {
+        this.previousSelectionRange = null
       }
     })
   },
@@ -268,6 +289,13 @@ export default {
       }
     },
     _handleEmojiPicked(emoji) {
+      if (this.sendEmojisDirectly) {
+        this._submitEmoji(emoji)
+      } else {
+        this._insertEmoji(emoji)
+      }
+    },
+    _submitEmoji(emoji) {
       this._checkSubmitSuccess(
         this.onSubmit({
           author: 'me',
@@ -275,6 +303,27 @@ export default {
           data: {emoji}
         })
       )
+    },
+    _insertEmoji(emoji) {
+      var range = this.previousSelectionRange
+      if (!range) {
+        console.log('First child: ' + this.$refs.userInput.firstChild)
+        range = document.createRange()
+        range.setStart(this.$refs.userInput.firstChild, this.$refs.userInput.textContent.length)
+        range.collapse(true)
+      }
+
+      var selection = window.getSelection()
+      selection.removeAllRanges()
+      selection.addRange(range)
+
+      var textNode = document.createTextNode(emoji)
+
+      range.deleteContents()
+      range.insertNode(textNode)
+      range.collapse(false)
+
+      this.$refs.userInput.focus()
     },
     _handleFileSubmit(file) {
       this.file = file


### PR DESCRIPTION
For my current project I needed to insert emojis into the input field rather then send them as a message directly.
This PR includes changes to realize that.

I have added a property `sendEmojisDirectly` that propagates towards the `UserInput`.
If set to `false` the new feature - respecting the last selection that has been made in the input fileld - will either insert the emoji at the caret or overwrite a selected range.